### PR TITLE
fix: double free issue with PkgFileCache

### DIFF
--- a/apt-pkg-c/cache.h
+++ b/apt-pkg-c/cache.h
@@ -153,11 +153,12 @@ inline void Cache::show_broken_package(const Package& pkg, bool now) const noexc
 }
 
 inline void Cache::show_broken(bool const Now) const noexcept {
-	PkgCacheFile Cache = *ptr;
-	if (Cache->BrokenCount() == 0) return;
-
+	// convert PkgCacheFile to pkgDepCache
+	// apt-pkg/cachefile.h: operator pkgDepCache &() const {return *DCache;};
+	if (((pkgDepCache&) ptr).BrokenCount() == 0) return;
+	
 	//    out << "The following packages have unmet dependencies:" << std::endl;
-	APT::PackageUniverse Universe(Cache);
+	APT::PackageUniverse Universe(&*ptr);
 	for (auto const& Pkg : Universe)
 		show_broken_package(Package{ std::make_unique<PkgIterator>(Pkg) }, Now);
 }


### PR DESCRIPTION
Fix #1 

Works as expected
![image](https://github.com/AOSC-Tracking/oma-apt/assets/45084815/78177c84-953f-442c-937b-78257d4b0073)
